### PR TITLE
Fix mod loading issues in game version 1.2.0

### DIFF
--- a/CheatMod.Core/CheatCommands/DestroyHittableResources/DestroyHittableResourcesCommandExecutor.cs
+++ b/CheatMod.Core/CheatCommands/DestroyHittableResources/DestroyHittableResourcesCommandExecutor.cs
@@ -48,23 +48,23 @@ public class DestroyHittableResourcesCommandExecutor : CheatCommandExecutor<Dest
 
     private void ProcessCaveOresShims(float range, PlayerStageController psc, CaveRoomEntity caveRoom)
     {
-        foreach (var shim in caveRoom.CurrentCaveOresShims.Where(sh => sh != null))
+        foreach (var shim in caveRoom.CurrentCaveOresShims.Where(sh => sh.Value != null))
         {
-            if (Vector2.Distance(shim.transform.position, psc.transform.position) >= range || shim.CurrentHealth <= 0f)
+            if (Vector2.Distance(shim.Value.transform.position, psc.transform.position) >= range || shim.Value.CurrentHealth <= 0f)
                 continue;
 
-            var healthComponent = GetHealthComponentFromShim(shim);
+            var healthComponent = GetHealthComponentFromShim(shim.Value);
             if (healthComponent != null && healthComponent.CurrentHealth > 0f)
             {
                 healthComponent.DecreaseHealth(healthComponent.CurrentHealth);
             }
 
             if (Application.isPlaying)
-                caveRoom.Pool.Release(shim);
+                caveRoom.Pool.Release(shim.Value);
             else
-                Object.DestroyImmediate(shim.gameObject);
+                Object.DestroyImmediate(shim.Value.gameObject);
 
-            caveRoom.CurrentCaveOresShims.Remove(shim);
+            caveRoom.CurrentCaveOresShims.Remove(shim.Key);
         }
     }
 

--- a/CheatMod.Core/CheatOptions.cs
+++ b/CheatMod.Core/CheatOptions.cs
@@ -64,8 +64,9 @@ public class CheatOptions
 
             _instance = newCheatOptions;
         }
-
-        _instance.ConfigChanged += () =>
+        
+        // Use Instance instead of _instance to ensure the object is created if no config file exists
+        Instance.ConfigChanged += () =>
         {
             new Task(() =>
             {

--- a/CheatMod.Core/Patches/InfiniteHarvest.cs
+++ b/CheatMod.Core/Patches/InfiniteHarvest.cs
@@ -1,6 +1,6 @@
 ﻿using HarmonyLib;
 using SodaDen.Pacha;
-using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace CheatMod.Core.Patches;
 
@@ -17,13 +17,18 @@ public partial class CheatModPatches
         return false;
     }
 
-    [HarmonyPatch(typeof(TreeEntity), "FruitToDrop", MethodType.Getter)]
-    [HarmonyPostfix]
-    private static void InfiniteTreeHarvestPatch(TreeEntity __instance, ref MagneticItemData[] __result)
+    [HarmonyPatch(typeof(TreeEntity), "ShakeAndDropFruit")]
+    [HarmonyPrefix]
+    private static bool InfiniteTreeHarvestPatch(TreeEntity __instance)
     {
         if (!CheatOptions.Instance.IsInfiniteHarvestEnabled.Value)
-            return;
+            return true;
 
-        for (var i = 0; i < __result.Length; i++) __result[i].ID = $"{__result[i].ID}-${Random.Range(1, int.MaxValue)}";
+        // TODO: Reimplement infinite tree harvest
+        // Problem: This new function does not return a value which is used, so the value cannot be patched 
+        // Meaning either the IL code needs to be modified, or the function needs to be duplicated here, which 
+        // will likely break with future updates
+        
+        return true;
     }
 }


### PR DESCRIPTION
The current version of the mod (v1.1.0.10) available on Nexus Mods is incompatible with the latest game update (v1.2.0). This PR introduces the minimal changes necessary to ensure the mod menu loads, and all cheats appear to function, albeit superficially.

This PR introduces one regression: 


<details> <summary>Infinite Harvest for Trees No Longer Works</summary>

In previous versions of the game, the `FruitToDrop` getter was modified to assign unique IDs to each fruit, allowing them to respawn. However, in v1.2.0, the new `ShakeAndDropFruit` function handles fruit spawning directly, without returning values that can be easily modified.

To restore this functionality, it would be needed to either override the `ShakeAndDropFruit` method with a prefix or modify the IL code to generate random IDs for each fruit. This approach was beyond the scope of this PR, but a possible minimal solution would involve replacing the loop index with a random number to ensure unique IDs.

</details>

### Additional Notes:

Upon starting the game, several errors and warnings appear in the output log related to this mod. These include:

- Errors related to skipping the credits and disclaimer.
- A missing object reference in `TreeRenderer.UpdateFromData` (specifically in `SpriteExtensions.Data`).
- Multiple `NullReferenceException`s throughout the UI code.

As I am not deeply familiar with the mod's source code or the underlying changes in the game’s update, I did not attempt to resolve these issues. They might require further investigation

### DLL File as interim solution:

I’ve attached a compiled version of the mod, which should work with v1.2.0 as a temporary solution until the repository is fully updated and the mod is officially released on Nexus Mods.
Find it here: [CheatMod.zip](https://github.com/user-attachments/files/17267655/CheatMod.zip)

Closes #2 